### PR TITLE
feat: 0.1.3 update palette.py to use the new s4c header

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s4c-scripts"
-version = "0.1.3-dev"
+version = "0.1.3"
 authors = [
     { name="jgabaut", email="jgabaut@github.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s4c-scripts"
-version = "0.1.2"
+version = "0.1.3-dev"
 authors = [
     { name="jgabaut", email="jgabaut@github.com" },
 ]

--- a/s4c/core/palette.py
+++ b/s4c/core/palette.py
@@ -28,7 +28,7 @@
 #
 # @section author_palette Author(s)
 # - Created by jgabaut on 01/09/2023.
-# - Modified by jgabaut on 19/01/2024.
+# - Modified by jgabaut on 29/08/2024.
 
 # Imports
 import sys
@@ -37,7 +37,7 @@ from .utils import convert_mode_lit
 
 ## The file format version.
 FILE_VERSION = "0.2.2"
-SCRIPT_VERSION = "0.1.0"
+SCRIPT_VERSION = "0.1.1"
 F_STRING_ARGS = "<mode> <palette> <s4c path>"
 
 # Expects the palette name as first argument, output directory as second argument.
@@ -109,7 +109,7 @@ def convert_palette(mode, palette_path, s4c_path):
     if mode == "header":
         print(f"#ifndef {target_name.upper()}_S4C_H_")
         print(f"#define {target_name.upper()}_S4C_H_")
-        print(f"#include \"{s4c_path}/sprites4curses/s4c-animate/animate.h\"\n")
+        print(f"#include \"{s4c_path}/sprites4curses/src/s4c.h\"\n")
         print(f"#define {target_name.upper()}_S4C_H_VERSION \"{FILE_VERSION}\"")
         print(f"#define {target_name.upper()}_S4C_H_TOTCOLORS {read_colors}")
         print("\n/**")

--- a/s4c/s4c_cli.py
+++ b/s4c/s4c_cli.py
@@ -42,7 +42,7 @@ from .core.sprites import main as sprites_main
 from .core.sheet_converter import main as sheet_converter_main
 from .core.png_resize import main as png_resize_main
 
-S4C_CLI_VERSION = "0.1.3-dev"
+S4C_CLI_VERSION = "0.1.3"
 
 EXPECTED_S4C_ANIMATE_V = "0.4.8"
 

--- a/s4c/s4c_cli.py
+++ b/s4c/s4c_cli.py
@@ -44,7 +44,7 @@ from .core.png_resize import main as png_resize_main
 
 S4C_CLI_VERSION = "0.1.3-dev"
 
-EXPECTED_S4C_ANIMATE_V = "0.4.2"
+EXPECTED_S4C_ANIMATE_V = "0.4.8"
 
 subcoms = ["cut_sheet", "palette", "sprites", "sheet_converter", "png_resize", "help", "version"]
 f_prog_str = f"{os.path.basename(__file__)}"

--- a/s4c/s4c_cli.py
+++ b/s4c/s4c_cli.py
@@ -42,7 +42,7 @@ from .core.sprites import main as sprites_main
 from .core.sheet_converter import main as sheet_converter_main
 from .core.png_resize import main as png_resize_main
 
-S4C_CLI_VERSION = "0.1.2"
+S4C_CLI_VERSION = "0.1.3-dev"
 
 EXPECTED_S4C_ANIMATE_V = "0.4.2"
 


### PR DESCRIPTION
- Update `palette` subcommand to use the new `s4c` header
- Compatible with `sprites4curses` `>=0.4.8`